### PR TITLE
Fix for Ubuntu 14.04, CentOS should work too

### DIFF
--- a/client.c
+++ b/client.c
@@ -19,6 +19,7 @@ int main(int argc, char *argv[])
     struct timeval tv;
 
     tv.tv_sec = timeout;
+    tv.tv_usec = 0;
 
     server = gethostbyname(host);
     bcopy((char *)server->h_addr, (char *)&serv_addr.sin_addr.s_addr, server->h_length);


### PR DESCRIPTION
Assign zero to tv.tv_usec, or it maybe any value.
The c version tiemout works on Ubuntu 14.04 after my fix.
